### PR TITLE
Add theme selection and settings page (issue #20)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,23 +1,177 @@
 .App {
-  text-align: center;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.App-header {
+  padding: 0.75rem 1.5rem;
+}
+
+.App-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.App-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.App-nav-links {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.App-nav-link {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.App-nav-link:hover {
+  text-decoration: underline;
+}
+
+.App-nav-link.is-active {
+  text-decoration: none;
+}
+
+main {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: #282c34;
+  padding: 2rem 1rem 3rem;
 }
 
-.App-header {
-  color: white;
+main > * {
+  max-width: 640px;
+  text-align: center;
 }
 
-.App-header h1 {
-  font-size: 3rem;
-  margin-bottom: 1rem;
+main h1 + p {
+  margin-top: 0.75rem;
 }
 
-.App-header p {
-  font-size: 1.5rem;
-  color: #61dafb;
+.Settings {
+  text-align: left;
+}
+
+.Settings-group {
+  margin-top: 1.5rem;
+}
+
+.Settings-theme-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.Settings-theme-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Base theme variables (Solarized palette) */
+:root {
+  --solarized-base03: #002b36;
+  --solarized-base02: #073642;
+  --solarized-base01: #586e75;
+  --solarized-base00: #657b83;
+  --solarized-base0: #839496;
+  --solarized-base1: #93a1a1;
+  --solarized-base2: #eee8d5;
+  --solarized-base3: #fdf6e3;
+  --solarized-yellow: #b58900;
+  --solarized-orange: #cb4b16;
+  --solarized-red: #dc322f;
+  --solarized-magenta: #d33682;
+  --solarized-violet: #6c71c4;
+  --solarized-blue: #268bd2;
+  --solarized-cyan: #2aa198;
+  --solarized-green: #859900;
+}
+
+/* Light theme */
+.theme-light {
+  background-color: #f5f5f5;
+  color: #222222;
+}
+
+.theme-light .App-header {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.theme-light .App-nav-link.is-active {
+  background-color: #222222;
+  color: #ffffff;
+}
+
+/* Dark theme (generic) */
+.theme-dark {
+  background-color: #121212;
+  color: #f5f5f5;
+}
+
+.theme-dark .App-header {
+  background-color: #1e1e1e;
+  border-bottom: 1px solid #333333;
+}
+
+.theme-dark .App-nav-link.is-active {
+  background-color: #f5f5f5;
+  color: #121212;
+}
+
+/* Solarized Light */
+.theme-solarized-light {
+  background-color: var(--solarized-base3);
+  color: var(--solarized-base00);
+}
+
+.theme-solarized-light .App-header {
+  background-color: var(--solarized-base2);
+  border-bottom: 1px solid var(--solarized-base1);
+}
+
+.theme-solarized-light .App-nav-link.is-active {
+  background-color: var(--solarized-blue);
+  color: var(--solarized-base3);
+}
+
+.theme-solarized-light a {
+  color: var(--solarized-blue);
+}
+
+/* Solarized Dark */
+.theme-solarized-dark {
+  background-color: var(--solarized-base03);
+  color: var(--solarized-base0);
+}
+
+.theme-solarized-dark .App-header {
+  background-color: var(--solarized-base02);
+  border-bottom: 1px solid var(--solarized-base01);
+}
+
+.theme-solarized-dark .App-nav-link.is-active {
+  background-color: var(--solarized-blue);
+  color: var(--solarized-base3);
+}
+
+.theme-solarized-dark a {
+  color: var(--solarized-cyan);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -34,7 +34,9 @@
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .App-nav-link:hover {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,121 @@
+import { useEffect, useState } from 'react';
 import './App.css';
 
+const THEME_STORAGE_KEY = 'claude-workflow-demo:theme';
+
+const THEMES = ['light', 'dark', 'solarized-light', 'solarized-dark'];
+
+function getPreferredTheme() {
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored && THEMES.includes(stored)) {
+    return stored;
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  if (prefersDark) {
+    return 'dark';
+  }
+
+  return 'light';
+}
+
 function App() {
+  const [theme, setTheme] = useState(() => getPreferredTheme());
+  const [view, setView] = useState('home');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const handleThemeChange = (event) => {
+    const newTheme = event.target.value;
+    if (THEMES.includes(newTheme)) {
+      setTheme(newTheme);
+    }
+  };
+
   return (
-    <div className="App">
+    <div className={`App theme-${theme}`}>
       <header className="App-header">
-        <h1>Hello World</h1>
+        <nav className="App-nav">
+          <div className="App-title">Claude Workflow Demo</div>
+          <div className="App-nav-links">
+            <button
+              type="button"
+              className={view === 'home' ? 'App-nav-link is-active' : 'App-nav-link'}
+              onClick={() => setView('home')}
+            >
+              Home
+            </button>
+            <button
+              type="button"
+              className={view === 'settings' ? 'App-nav-link is-active' : 'App-nav-link'}
+              onClick={() => setView('settings')}
+            >
+              Settings
+            </button>
+          </div>
+        </nav>
       </header>
       <main>
-        <p>Welcome to Claude Workflow Demo!</p>
+        {view === 'home' && (
+          <>
+            <h1>Hello World</h1>
+            <p>Welcome to Claude Workflow Demo!</p>
+          </>
+        )}
+        {view === 'settings' && (
+          <section aria-label="Theme settings" className="Settings">
+            <h1>Settings</h1>
+            <div className="Settings-group">
+              <h2>Theme</h2>
+              <p>Select your preferred theme. This will be saved on this device.</p>
+              <div className="Settings-theme-options">
+                <label>
+                  <input
+                    type="radio"
+                    name="theme"
+                    value="light"
+                    checked={theme === 'light'}
+                    onChange={handleThemeChange}
+                  />
+                  Light
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="theme"
+                    value="dark"
+                    checked={theme === 'dark'}
+                    onChange={handleThemeChange}
+                  />
+                  Dark
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="theme"
+                    value="solarized-light"
+                    checked={theme === 'solarized-light'}
+                    onChange={handleThemeChange}
+                  />
+                  Solarized Light
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="theme"
+                    value="solarized-dark"
+                    checked={theme === 'solarized-dark'}
+                    onChange={handleThemeChange}
+                  />
+                  Solarized Dark
+                </label>
+              </div>
+            </div>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,9 @@ function getPreferredTheme() {
     return stored;
   }
 
-  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  const prefersDark = window.matchMedia?.(
+    '(prefers-color-scheme: dark)'
+  ).matches;
   if (prefersDark) {
     return 'dark';
   }
@@ -28,7 +30,7 @@ function App() {
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
-  const handleThemeChange = (event) => {
+  const handleThemeChange = event => {
     const newTheme = event.target.value;
     if (THEMES.includes(newTheme)) {
       setTheme(newTheme);
@@ -43,14 +45,18 @@ function App() {
           <div className="App-nav-links">
             <button
               type="button"
-              className={view === 'home' ? 'App-nav-link is-active' : 'App-nav-link'}
+              className={
+                view === 'home' ? 'App-nav-link is-active' : 'App-nav-link'
+              }
               onClick={() => setView('home')}
             >
               Home
             </button>
             <button
               type="button"
-              className={view === 'settings' ? 'App-nav-link is-active' : 'App-nav-link'}
+              className={
+                view === 'settings' ? 'App-nav-link is-active' : 'App-nav-link'
+              }
               onClick={() => setView('settings')}
             >
               Settings
@@ -70,7 +76,9 @@ function App() {
             <h1>Settings</h1>
             <div className="Settings-group">
               <h2>Theme</h2>
-              <p>Select your preferred theme. This will be saved on this device.</p>
+              <p>
+                Select your preferred theme. This will be saved on this device.
+              </p>
               <div className="Settings-theme-options">
                 <label>
                   <input

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ function getPreferredTheme() {
     if (stored && THEMES.includes(stored)) {
       return stored;
     }
-  } catch (e) {
+  } catch {
     // localStorage not available (private browsing, SSR, etc.)
   }
 
@@ -37,7 +37,7 @@ function App() {
   useEffect(() => {
     try {
       window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-    } catch (e) {
+    } catch {
       // localStorage not available - theme still works, just won't persist
     }
   }, [theme]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import './App.css';
 
 const THEME_STORAGE_KEY = 'claude-workflow-demo:theme';
 
 const THEMES = ['light', 'dark', 'solarized-light', 'solarized-dark'];
 
+const VIEWS = {
+  HOME: 'home',
+  SETTINGS: 'settings',
+};
+
 function getPreferredTheme() {
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-  if (stored && THEMES.includes(stored)) {
-    return stored;
+  try {
+    const stored = window.localStorage?.getItem(THEME_STORAGE_KEY);
+    if (stored && THEMES.includes(stored)) {
+      return stored;
+    }
+  } catch (e) {
+    // localStorage not available (private browsing, SSR, etc.)
   }
 
   const prefersDark = window.matchMedia?.(
@@ -23,19 +32,22 @@ function getPreferredTheme() {
 
 function App() {
   const [theme, setTheme] = useState(() => getPreferredTheme());
-  const [view, setView] = useState('home');
+  const [view, setView] = useState(VIEWS.HOME);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch (e) {
+      // localStorage not available - theme still works, just won't persist
+    }
   }, [theme]);
 
-  const handleThemeChange = event => {
+  const handleThemeChange = useCallback(event => {
     const newTheme = event.target.value;
     if (THEMES.includes(newTheme)) {
       setTheme(newTheme);
     }
-  };
+  }, []);
 
   return (
     <div className={`App theme-${theme}`}>
@@ -46,18 +58,20 @@ function App() {
             <button
               type="button"
               className={
-                view === 'home' ? 'App-nav-link is-active' : 'App-nav-link'
+                view === VIEWS.HOME ? 'App-nav-link is-active' : 'App-nav-link'
               }
-              onClick={() => setView('home')}
+              onClick={() => setView(VIEWS.HOME)}
             >
               Home
             </button>
             <button
               type="button"
               className={
-                view === 'settings' ? 'App-nav-link is-active' : 'App-nav-link'
+                view === VIEWS.SETTINGS
+                  ? 'App-nav-link is-active'
+                  : 'App-nav-link'
               }
-              onClick={() => setView('settings')}
+              onClick={() => setView(VIEWS.SETTINGS)}
             >
               Settings
             </button>
@@ -65,13 +79,13 @@ function App() {
         </nav>
       </header>
       <main>
-        {view === 'home' && (
+        {view === VIEWS.HOME && (
           <>
             <h1>Hello World</h1>
             <p>Welcome to Claude Workflow Demo!</p>
           </>
         )}
-        {view === 'settings' && (
+        {view === VIEWS.SETTINGS && (
           <section aria-label="Theme settings" className="Settings">
             <h1>Settings</h1>
             <div className="Settings-group">

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
+
+beforeEach(() => {
+  // Clear localStorage before each test
+  window.localStorage.clear();
+  // Reset matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    }),
+  });
+});
 
 describe('App', () => {
   it('renders hello world heading', () => {
@@ -65,5 +84,82 @@ describe('App', () => {
 
     const root = document.querySelector('.App');
     expect(root.className).toContain('theme-solarized-dark');
+  });
+
+  it('persists theme selection to localStorage', () => {
+    render(<App />);
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const darkTheme = screen.getByRole('radio', { name: /^dark$/i });
+    fireEvent.click(darkTheme);
+
+    expect(window.localStorage.getItem('claude-workflow-demo:theme')).toBe(
+      'dark'
+    );
+  });
+
+  it('loads theme from localStorage on initial render', () => {
+    window.localStorage.setItem(
+      'claude-workflow-demo:theme',
+      'solarized-light'
+    );
+
+    render(<App />);
+
+    const root = document.querySelector('.App');
+    expect(root.className).toContain('theme-solarized-light');
+  });
+
+  it('uses system preference when no stored theme', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: query => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => {},
+      }),
+    });
+
+    render(<App />);
+
+    const root = document.querySelector('.App');
+    expect(root.className).toContain('theme-dark');
+  });
+
+  it('defaults to light theme when no stored theme and no dark mode preference', () => {
+    render(<App />);
+
+    const root = document.querySelector('.App');
+    expect(root.className).toContain('theme-light');
+  });
+
+  it('handles localStorage errors gracefully', () => {
+    // Mock localStorage to throw an error
+    const originalSetItem = window.localStorage.setItem;
+    window.localStorage.setItem = () => {
+      throw new Error('localStorage not available');
+    };
+
+    render(<App />);
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const darkTheme = screen.getByRole('radio', { name: /^dark$/i });
+    fireEvent.click(darkTheme);
+
+    // Should still update the theme class even if localStorage fails
+    const root = document.querySelector('.App');
+    expect(root.className).toContain('theme-dark');
+
+    // Restore original function
+    window.localStorage.setItem = originalSetItem;
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -39,8 +39,12 @@ describe('App', () => {
 
     const light = screen.getByRole('radio', { name: /^light$/i });
     const dark = screen.getByRole('radio', { name: /^dark$/i });
-    const solarizedLight = screen.getByRole('radio', { name: /solarized light/i });
-    const solarizedDark = screen.getByRole('radio', { name: /solarized dark/i });
+    const solarizedLight = screen.getByRole('radio', {
+      name: /solarized light/i,
+    });
+    const solarizedDark = screen.getByRole('radio', {
+      name: /solarized dark/i,
+    });
 
     expect(light).toBeInTheDocument();
     expect(dark).toBeInTheDocument();
@@ -54,11 +58,12 @@ describe('App', () => {
     const settingsButton = screen.getByRole('button', { name: /settings/i });
     fireEvent.click(settingsButton);
 
-    const solarizedDark = screen.getByRole('radio', { name: /solarized dark/i });
+    const solarizedDark = screen.getByRole('radio', {
+      name: /solarized dark/i,
+    });
     fireEvent.click(solarizedDark);
 
     const root = document.querySelector('.App');
     expect(root.className).toContain('theme-solarized-dark');
   });
 });
-

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
 describe('App', () => {
@@ -20,4 +20,45 @@ describe('App', () => {
     const mainElement = screen.getByRole('main');
     expect(mainElement).toBeInTheDocument();
   });
+
+  it('shows navigation with Home and Settings buttons', () => {
+    render(<App />);
+
+    const homeButton = screen.getByRole('button', { name: /home/i });
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+
+    expect(homeButton).toBeInTheDocument();
+    expect(settingsButton).toBeInTheDocument();
+  });
+
+  it('shows theme options on the settings view', () => {
+    render(<App />);
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const light = screen.getByRole('radio', { name: /^light$/i });
+    const dark = screen.getByRole('radio', { name: /^dark$/i });
+    const solarizedLight = screen.getByRole('radio', { name: /solarized light/i });
+    const solarizedDark = screen.getByRole('radio', { name: /solarized dark/i });
+
+    expect(light).toBeInTheDocument();
+    expect(dark).toBeInTheDocument();
+    expect(solarizedLight).toBeInTheDocument();
+    expect(solarizedDark).toBeInTheDocument();
+  });
+
+  it('updates the theme class when selecting a different theme', () => {
+    render(<App />);
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const solarizedDark = screen.getByRole('radio', { name: /solarized dark/i });
+    fireEvent.click(solarizedDark);
+
+    const root = document.querySelector('.App');
+    expect(root.className).toContain('theme-solarized-dark');
+  });
 });
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,10 +3,6 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,8 +11,6 @@
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
This PR implements issue #20 by adding theme support and a settings page.\n\n- Adds a navigation bar with Home and Settings views in App.\n- Implements theme detection using localStorage (claude-workflow-demo:theme) and system dark-mode preference, defaulting to light.\n- Supports four themes: light, dark, solarized-light, solarized-dark using the official Solarized palette.\n- Persists theme selection in localStorage and applies it via .App theme-<name> classes.\n- Adds a Settings view with a theme selector and associated tests.\n- Keeps the original Hello World / welcome content on the Home view.\n\nAll tests pass via `npm test`.